### PR TITLE
Use less generic environment variable & update Dockerfiles

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,7 +148,7 @@ PingResource.java
 include::finish/ping/src/main/java/io/openliberty/guides/ping/PingResource.java[tags=**;!copyright;]
 ----
 
-The changes introduced here use MicroProfile Config and CDI to inject the value of the environment variables [hotspot=28-30]`USERNAME` and [hotspot=32-34]`PASSWORD` into the [hotspot=26-76]`PingResource` class.
+The changes introduced here use MicroProfile Config and CDI to inject the value of the environment variables [hotspot=28-30]`PING_USERNAME` and [hotspot=32-34]`PING_PASSWORD` into the [hotspot=26-76]`PingResource` class.
 
 
 == Creating a ConfigMap and Secret
@@ -189,7 +189,7 @@ include::finish/name/Dockerfile[]
 
 Next, you will update your {kube} deployments to set the environment variables in your containers based on the values configured in the ConfigMap and Secret created previously. 
 The [hotspot=22-27]`env` section under the [hotspot=17-27]`name-container` is where the `GREETING` environment variable will be set.
-The [hotspot=50-60]`env` section under the [hotspot=45-60]`ping-container` is where the [hotspot=51-55]`USERNAME` and [hotspot=56-60]`PASSWORD` environment variables will be set.
+The [hotspot=50-60]`env` section under the [hotspot=45-60]`ping-container` is where the [hotspot=51-55]`PING_USERNAME` and [hotspot=56-60]`PING_PASSWORD` environment variables will be set.
 
 [role="code_command hotspot", subs="quotes"]
 ----

--- a/finish/kubernetes.yaml
+++ b/finish/kubernetes.yaml
@@ -46,14 +46,14 @@ spec:
         image: ping:1.0-SNAPSHOT
         ports:
         - containerPort: 9080
-        # Set the USERNAME and PASSWORD environment variables
+        # Set the PING_USERNAME and PING_PASSWORD environment variables
         env:
-        - name: USERNAME
+        - name: PING_USERNAME
           valueFrom:
             secretKeyRef:
               name: name-credentials
               key: username
-        - name: PASSWORD
+        - name: PING_PASSWORD
           valueFrom:
             secretKeyRef:
               name: name-credentials

--- a/finish/name/Dockerfile
+++ b/finish/name/Dockerfile
@@ -1,5 +1,5 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/name.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/name.war

--- a/finish/ping/Dockerfile
+++ b/finish/ping/Dockerfile
@@ -1,5 +1,5 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/ping.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/ping.war

--- a/finish/ping/src/main/java/io/openliberty/guides/ping/PingResource.java
+++ b/finish/ping/src/main/java/io/openliberty/guides/ping/PingResource.java
@@ -39,11 +39,11 @@ public class PingResource {
 
     // tag::credentials[]
     @Inject
-    @ConfigProperty(name = "USERNAME")
+    @ConfigProperty(name = "PING_USERNAME")
     private String username;
 
     @Inject
-    @ConfigProperty(name = "PASSWORD")
+    @ConfigProperty(name = "PING_PASSWORD")
     private String password;
     // end::credentials[]
 

--- a/start/name/Dockerfile
+++ b/start/name/Dockerfile
@@ -1,5 +1,5 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/name.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/name.war

--- a/start/ping/Dockerfile
+++ b/start/ping/Dockerfile
@@ -1,5 +1,5 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/ping.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/ping.war


### PR DESCRIPTION
- Change `USERNAME` and `PASSWORD` environment variables to `PING_USERNAME` and `PING_PASSWORD` to be more descriptive.
- Update permissions during COPY in Dockerfiles,  since OL images now run as non-root, we have to make sure that all the artifacts being copied into the image have the correct permissions to be read and executed by user 1001 or group 0.