### PR TITLE
Travis.yml adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - wget https://github.com/kubernetes/minikube/releases/download/v0.28.2/minikube-linux-amd64 -q -O minikube
 - chmod +x minikube
 - sudo ln -s $(pwd)/minikube /usr/local/bin/minikube
-- sudo minikube start --vm-driver=none --bootstrapper=localkube
+- sudo minikube start --vm-driver=none --bootstrapper=kubeadm
 - ../scripts/travisTest.sh
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_script:
 - cd finish
 - chmod +x ../scripts/travisTest.sh
 script: 
-- sudo mount --make-rshared /
 - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 - chmod +x kubectl
 - sudo ln -s $(pwd)/kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
Removed `mount` command
Updated minikube bootstrapper from `localkube` (deprecated) to `kubeadm`

Related to https://github.com/openliberty/guide-kubernetes-microprofile-config/issues/36