### PR TITLE
Update to MP6.1

### DIFF
--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -19,8 +19,8 @@
         <system.service.root>localhost:31000</system.service.root>
         <inventory.service.root>localhost:32000</inventory.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,25 +42,25 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <!-- For tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,19 +83,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.kube.service>${system.kube.service}</system.kube.service>

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,8 +41,8 @@ public class SystemClient {
   // end::context-root[]
 
   @Inject
-  @ConfigProperty(name = "default.http.port")
-  String DEFAULT_PORT;
+  @ConfigProperty(name = "http.port")
+  String HTTP_PORT;
 
   // Basic Auth Credentials
   // tag::credentials[]
@@ -79,7 +79,7 @@ public class SystemClient {
   private Builder getBuilder(String hostname, Client client) throws Exception {
     // tag::context-root1[]
     URI uri = new URI(
-                  PROTOCOL, null, hostname, Integer.valueOf(DEFAULT_PORT),
+                  PROTOCOL, null, hostname, Integer.valueOf(HTTP_PORT),
                   CONTEXT_ROOT + SYSTEM_PROPERTIES, null, null);
     // end::context-root1[]
     String urlString = uri.toString();

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryLivenessCheck.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryLivenessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ public class InventoryReadinessCheck implements HealthCheck {
         try {
             Client client = ClientBuilder.newClient();
             client
-                .target("http://" + hostname + ":9080/system/properties")
+                .target("http://" + hostname + ":9090/system/properties")
                 .request()
                 .post(null);
 

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryStartupCheck.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryStartupCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/model/SystemData.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/model/SystemData.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -4,16 +4,16 @@
     <feature>restfulWS-3.1</feature>
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>jsonp-2.1</feature>
     <feature>mpHealth-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-kubernetes-microprofile-config-inventory.war" contextRoot="/"/>
 

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
             </ul>

--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/kubernetes.yaml
+++ b/finish/kubernetes.yaml
@@ -23,16 +23,16 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # system probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -40,7 +40,7 @@ spec:
         readinessProbe:
            httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 3
@@ -121,16 +121,16 @@ spec:
       - name: inventory-container
         image: inventory:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # inventory probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -138,7 +138,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 3
@@ -206,8 +206,8 @@ spec:
     app: system
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 31000
 ---
 apiVersion: v1
@@ -220,6 +220,6 @@ spec:
     app: inventory
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 32000

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -18,8 +18,8 @@
         <system.service.root>localhost:31000</system.service.root>
         <system.appName>system</system.appName>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -41,19 +41,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -70,19 +70,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.service.root>${system.service.root}</system.service.root>

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/system/src/main/java/io/openliberty/guides/system/health/SystemLivenessCheck.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/health/SystemLivenessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/system/src/main/java/io/openliberty/guides/system/health/SystemReadinessCheck.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/health/SystemReadinessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/system/src/main/java/io/openliberty/guides/system/health/SystemStartupCheck.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/health/SystemStartupCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -5,21 +5,21 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>jsonp-2.1</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpHealth-4.0</feature>
     <feature>appSecurity-5.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
   <variable name="system.app.username" defaultValue="bob"/>
   <variable name="system.app.password" defaultValue="bobpwd"/>
   <!-- tag::context.root[] -->
   <variable name="context.root" defaultValue="/"/>
   <!-- end::context.root[] -->
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint" />
 
   <!-- tag::webApplication[] -->
   <webApplication location="guide-kubernetes-microprofile-config-system.war" contextRoot="${context.root}"/>

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#appSecurity-5.0.html">Application Security 5.0</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -19,8 +19,8 @@
         <system.service.root>localhost:31000</system.service.root>
         <inventory.service.root>localhost:32000</inventory.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,25 +42,25 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <!-- For tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,19 +83,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.kube.service>${system.kube.service}</system.kube.service>

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,8 +35,8 @@ public class SystemClient {
   private final String PROTOCOL = "http";
 
   @Inject
-  @ConfigProperty(name = "default.http.port")
-  String DEFAULT_PORT;
+  @ConfigProperty(name = "http.port")
+  String HTTP_PORT;
 
   // Basic Auth Credentials
   private String username = "bob";
@@ -61,7 +61,7 @@ public class SystemClient {
   // Method that creates the client builder
   private Builder getBuilder(String hostname, Client client) throws Exception {
     URI uri = new URI(
-                  PROTOCOL, null, hostname, Integer.valueOf(DEFAULT_PORT),
+                  PROTOCOL, null, hostname, Integer.valueOf(HTTP_PORT),
                   SYSTEM_PROPERTIES, null, null);
     String urlString = uri.toString();
     Builder builder = client.target(urlString).request();

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryLivenessCheck.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryLivenessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ public class InventoryReadinessCheck implements HealthCheck {
         try {
             Client client = ClientBuilder.newClient();
             client
-                .target("http://" + hostname + ":9080/system/properties")
+                .target("http://" + hostname + ":9090/system/properties")
                 .request()
                 .post(null);
 

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryStartupCheck.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryStartupCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/model/SystemData.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/model/SystemData.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -4,16 +4,16 @@
     <feature>restfulWS-3.1</feature>
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpHealth-4.0</feature>
     <feature>jsonp-2.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-kubernetes-microprofile-config-inventory.war" contextRoot="/"/>
 

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
             </ul>

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/kubernetes.yaml
+++ b/start/kubernetes.yaml
@@ -22,16 +22,16 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # system probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -39,7 +39,7 @@ spec:
         readinessProbe:
            httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 3
@@ -69,16 +69,16 @@ spec:
       - name: inventory-container
         image: inventory:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # inventory probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -86,7 +86,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 3
@@ -106,8 +106,8 @@ spec:
     app: system
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 31000
 ---
 apiVersion: v1
@@ -120,6 +120,6 @@ spec:
     app: inventory
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 32000

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -17,8 +17,8 @@
         <!-- Default test properties -->
         <system.service.root>localhost:31000</system.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -40,19 +40,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -69,19 +69,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.service.root>${system.service.root}</system.service.root>

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/system/src/main/java/io/openliberty/guides/system/health/SystemLivenessCheck.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/health/SystemLivenessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/system/src/main/java/io/openliberty/guides/system/health/SystemReadinessCheck.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/health/SystemReadinessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/system/src/main/java/io/openliberty/guides/system/health/SystemStartupCheck.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/health/SystemStartupCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -5,18 +5,18 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>jsonp-2.1</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpHealth-4.0</feature>
     <feature>appSecurity-5.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
   <variable name="system.app.username" defaultValue="bob"/>
   <variable name="system.app.password" defaultValue="bobpwd"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-kubernetes-microprofile-config-system.war" contextRoot="/"/>
 

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#appSecurity-5.0.html">Application Security 5.0</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>

--- a/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

