### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/README.adoc
+++ b/README.adoc
@@ -293,6 +293,12 @@ kubectl create configmap sys-app-root --from-literal contextRoot=/dev
 
 This command deploys a ConfigMap named `sys-app-root` to your cluster. It has a key called `contextRoot` with a value of `/dev`. The `--from-literal` flag allows you to specify individual key-value pairs to store in this ConfigMap. Other available options, such as `--from-file` and `--from-env-file`, provide more versatility as to what you want to configure. Details about these options can be found in the https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-configmap-em-[{kube} CLI documentation^].
 
+Run the following command to display details of the ConfigMap.
+[role='command']
+```
+kubectl describe configmaps sys-app-root
+```
+
 Create a Secret to configure the new credentials that `inventory` uses to authenticate against `system` with the following `kubectl` command.
 [role='command']
 ```
@@ -300,6 +306,12 @@ kubectl create secret generic sys-app-credentials --from-literal username=alice 
 ```
  
 This command looks similar to the command to create a ConfigMap, but one difference is the word `generic`. This word creates a Secret that doesn't store information in any specialized way. Different types of secrets are available, such as secrets to store Docker credentials and secrets to store public and private key pairs.
+
+Run the following command to display details of the Secret.
+[role='command']
+```
+kubectl describe secrets/sys-app-credentials
+```
 
 A Secret is similar to a ConfigMap. A key difference is that a Secret is used for confidential information such as credentials. One of the main differences is that you must explicitly tell `kubectl` to show you the contents of a Secret. Additionally, when it does show you the information, it only shows you a Base64 encoded version so that a casual onlooker doesn't accidentally see any sensitive data. Secrets don't provide any encryption by default, that is something you'll either need to do yourself or find an alternate option to configure. Encryption is not required for the application to run.
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2023 IBM Corporation and others.
+// Copyright (c) 2018, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -11,7 +11,7 @@
 :page-duration: 15 minutes
 :page-releasedate: 2018-10-12
 :page-description: Externalize configuration and use Kubernetes ConfigMaps and Secrets to configure your microservices.
-:page-tags: ['Kubernetes', 'Docker', 'MicroProfile']
+:page-tags: ['kubernetes', 'docker', 'microprofile']
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['kubernetes-intro', 'microprofile-config', 'cdi-intro', 'docker']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
@@ -204,13 +204,13 @@ ifdef::cloud-hosted[]
 In this IBM cloud environment, you need to set up port forwarding to access the services. Open another command-line session by selecting **Terminal** > **New Terminal** from the menu of the IDE. Run the following commands to set up port forwarding to access the **system** service.
 ```bash
 SYSTEM_NODEPORT=`kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services system-service`
-kubectl port-forward svc/system-service $SYSTEM_NODEPORT:9080
+kubectl port-forward svc/system-service $SYSTEM_NODEPORT:9090
 ```
 
 Then, open another command-line session by selecting **Terminal** > **New Terminal** from the menu of the IDE. Run the following commands to set up port forwarding to access the **inventory** service.
 ```bash
 INVENTORY_NODEPORT=`kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services inventory-service`
-kubectl port-forward svc/inventory-service $INVENTORY_NODEPORT:9080
+kubectl port-forward svc/inventory-service $INVENTORY_NODEPORT:9090
 ```
 
 Then use the following commands to access your **system** microservice. The ***-u*** option is used to pass in the username ***bob*** and the password ***bobpwd***.
@@ -441,14 +441,14 @@ Run the following commands to set up port forwarding to access the ***system*** 
 
 ```bash
 SYSTEM_NODEPORT=`kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services system-service`
-kubectl port-forward svc/system-service $SYSTEM_NODEPORT:9080
+kubectl port-forward svc/system-service $SYSTEM_NODEPORT:9090
 ```
 
 Then, run the following commands to set up port forwarding to access the **inventory** service.
 
 ```bash
 INVENTORY_NODEPORT=`kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services inventory-service`
-kubectl port-forward svc/inventory-service $INVENTORY_NODEPORT:9080
+kubectl port-forward svc/inventory-service $INVENTORY_NODEPORT:9090
 ```
 
 You now need to use the new username, ***alice***, and the new password, ***wonderland***, to log in. Access your application with the following commands:

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -19,8 +19,8 @@
         <system.service.root>localhost:31000</system.service.root>
         <inventory.service.root>localhost:32000</inventory.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,8 +41,8 @@ public class SystemClient {
   // end::context-root[]
 
   @Inject
-  @ConfigProperty(name = "default.http.port")
-  String DEFAULT_PORT;
+  @ConfigProperty(name = "http.port")
+  String HTTP_PORT;
 
   // Basic Auth Credentials
   // tag::credentials[]
@@ -79,7 +79,7 @@ public class SystemClient {
   private Builder getBuilder(String hostname, Client client) throws Exception {
     // tag::context-root1[]
     URI uri = new URI(
-                  PROTOCOL, null, hostname, Integer.valueOf(DEFAULT_PORT),
+                  PROTOCOL, null, hostname, Integer.valueOf(HTTP_PORT),
                   CONTEXT_ROOT + SYSTEM_PROPERTIES, null, null);
     // end::context-root1[]
     String urlString = uri.toString();

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ public class InventoryReadinessCheck implements HealthCheck {
         try {
             Client client = ClientBuilder.newClient();
             client
-                .target("http://" + hostname + ":9080/system/properties")
+                .target("http://" + hostname + ":9090/system/properties")
                 .request()
                 .post(null);
 

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -4,16 +4,16 @@
     <feature>restfulWS-3.1</feature>
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>jsonp-2.1</feature>
     <feature>mpHealth-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-kubernetes-microprofile-config-inventory.war" contextRoot="/"/>
 

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
             </ul>

--- a/finish/kubernetes.yaml
+++ b/finish/kubernetes.yaml
@@ -23,16 +23,16 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # system probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -40,7 +40,7 @@ spec:
         readinessProbe:
            httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 3
@@ -121,16 +121,16 @@ spec:
       - name: inventory-container
         image: inventory:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # inventory probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -138,7 +138,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 3
@@ -206,8 +206,8 @@ spec:
     app: system
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 31000
 ---
 apiVersion: v1
@@ -220,6 +220,6 @@ spec:
     app: inventory
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 32000

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -18,8 +18,8 @@
         <system.service.root>localhost:31000</system.service.root>
         <system.appName>system</system.appName>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -5,21 +5,21 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>jsonp-2.1</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpHealth-4.0</feature>
     <feature>appSecurity-5.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
   <variable name="system.app.username" defaultValue="bob"/>
   <variable name="system.app.password" defaultValue="bobpwd"/>
   <!-- tag::context.root[] -->
   <variable name="context.root" defaultValue="/"/>
   <!-- end::context.root[] -->
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint" />
 
   <!-- tag::webApplication[] -->
   <webApplication location="guide-kubernetes-microprofile-config-system.war" contextRoot="${context.root}"/>

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#appSecurity-5.0.html">Application Security 5.0</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -19,8 +19,8 @@
         <system.service.root>localhost:31000</system.service.root>
         <inventory.service.root>localhost:32000</inventory.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,8 +35,8 @@ public class SystemClient {
   private final String PROTOCOL = "http";
 
   @Inject
-  @ConfigProperty(name = "default.http.port")
-  String DEFAULT_PORT;
+  @ConfigProperty(name = "http.port")
+  String HTTP_PORT;
 
   // Basic Auth Credentials
   private String username = "bob";
@@ -61,7 +61,7 @@ public class SystemClient {
   // Method that creates the client builder
   private Builder getBuilder(String hostname, Client client) throws Exception {
     URI uri = new URI(
-                  PROTOCOL, null, hostname, Integer.valueOf(DEFAULT_PORT),
+                  PROTOCOL, null, hostname, Integer.valueOf(HTTP_PORT),
                   SYSTEM_PROPERTIES, null, null);
     String urlString = uri.toString();
     Builder builder = client.target(urlString).request();

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/health/InventoryReadinessCheck.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,7 @@ public class InventoryReadinessCheck implements HealthCheck {
         try {
             Client client = ClientBuilder.newClient();
             client
-                .target("http://" + hostname + ":9080/system/properties")
+                .target("http://" + hostname + ":9090/system/properties")
                 .request()
                 .post(null);
 

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -4,16 +4,16 @@
     <feature>restfulWS-3.1</feature>
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpHealth-4.0</feature>
     <feature>jsonp-2.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-kubernetes-microprofile-config-inventory.war" contextRoot="/"/>
 

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
             </ul>

--- a/start/kubernetes.yaml
+++ b/start/kubernetes.yaml
@@ -22,16 +22,16 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # system probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -39,7 +39,7 @@ spec:
         readinessProbe:
            httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 3
@@ -69,16 +69,16 @@ spec:
       - name: inventory-container
         image: inventory:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
         # inventory probes
         startupProbe:
           httpGet:
             path: /health/started
-            port: 9080
+            port: 9090
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 9080
+            port: 9090
           initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
@@ -86,7 +86,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /health/ready
-            port: 9080
+            port: 9090
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 3
@@ -106,8 +106,8 @@ spec:
     app: system
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 31000
 ---
 apiVersion: v1
@@ -120,6 +120,6 @@ spec:
     app: inventory
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9090
+    targetPort: 9090
     nodePort: 32000

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -17,8 +17,8 @@
         <!-- Default test properties -->
         <system.service.root>localhost:31000</system.service.root>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
     </properties>
 
     <dependencies>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -5,18 +5,18 @@
     <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
     <feature>jsonp-2.1</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpHealth-4.0</feature>
     <feature>appSecurity-5.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
   <variable name="system.app.username" defaultValue="bob"/>
   <variable name="system.app.password" defaultValue="bobpwd"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
-    httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" 
+    httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="guide-kubernetes-microprofile-config-system.war" contextRoot="/"/>
 

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#appSecurity-5.0.html">Application Security 5.0</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

